### PR TITLE
Bump up IntelliJ version from 203.* to 211.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,5 +51,5 @@ tasks.getByName<PatchPluginXmlTask>("patchPluginXml") {
     changeNotes("""
       Fix bug with type code gen, make inputs bigger""")
     sinceBuild("201")
-    untilBuild("203.*")
+    untilBuild("211.*")
 }


### PR DESCRIPTION
Add support for the new IntelliJ 2021.1 release.